### PR TITLE
Fixed wrong file path for Chirp.sln in workflow build

### DIFF
--- a/.github/workflows/main_bdsagroup22chirprazor.yml
+++ b/.github/workflows/main_bdsagroup22chirprazor.yml
@@ -24,10 +24,10 @@ jobs:
           dotnet-version: '8.x'
 
       - name: Build with dotnet
-        run: dotnet build Chirp.sln --configuration Release
+        run: dotnet build Chirp/Chirp.sln --configuration Release
   
       - name: dotnet publish
-        run: dotnet publish Chirp.sln -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish Chirp/Chirp.sln -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
@@ -64,5 +64,6 @@ jobs:
           package: .
 
           
+
 
 


### PR DESCRIPTION
The file path we previously specified did not make sense. We should instead reference the solution file path.