### PR TITLE
Add sanitizer class for xss handling in Public.cshtml.cs

### DIFF
--- a/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Chirp.Infrastructure/InputSanitizer.cs
+++ b/src/Chirp.Infrastructure/InputSanitizer.cs
@@ -1,0 +1,35 @@
+﻿using System.Text.RegularExpressions;
+using System.Web;
+using Ganss.Xss; // Used for XSS cleaning
+
+namespace Chirp.Infrastructure;
+
+public interface IInputSanitizer
+{
+    string SanitizeCheepText(string input);
+}
+
+public class InputSanitizer : IInputSanitizer
+{
+    /**
+     * Sanitizes user input for malicious content like XSS attacks.
+     * 
+     * Relies on HtmlSanitizer package.
+     * 
+     * Takes the users input string as parameter and returns the "safe" string back.
+     * 
+     * Used in Public.cshtml.cs for method OnPostAsync before creating the cheep
+     * and adding it to the database.
+     */
+    public string SanitizeCheepText(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return string.Empty;
+        }
+        
+        var sanitizer = new HtmlSanitizer();
+        var cleanHtml = sanitizer.Sanitize(input);
+        return cleanHtml;
+    }
+}

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -13,6 +13,7 @@ public class PublicModel : PageModel
     private readonly ICheepRepository _cheepRepository;
     private readonly IAuthorRepository _authorRepository;
     private readonly ChirpContext _context;
+    private readonly IInputSanitizer _inputSanitizer;
 
     public List<CheepViewModel> Cheeps { get; set; } = new List<CheepViewModel>();
     
@@ -23,11 +24,17 @@ public class PublicModel : PageModel
     [Display(Name = "Cheep Text")]
     public string CheepText { get; set; } = "";
 
-    public PublicModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository, ChirpContext context)
+    public PublicModel(
+        ICheepRepository cheepRepository, 
+        IAuthorRepository authorRepository, 
+        ChirpContext context,
+        IInputSanitizer inputSanitizer
+        )
     {
         _cheepRepository = cheepRepository;
         _authorRepository = authorRepository;
         _context = context;
+        _inputSanitizer = inputSanitizer;
     }
     
     public Task<IActionResult> OnGetAsync(int page = 1, int pageSize = 32)
@@ -52,6 +59,8 @@ public class PublicModel : PageModel
             return RedirectToPage();
         }
     
+        var sanitizedText = _inputSanitizer.SanitizeCheepText(CheepText);
+        
         var author = _authorRepository.GetAuthorByName(userName);
 
         if (author == null)
@@ -71,7 +80,7 @@ public class PublicModel : PageModel
         var newCheep = new Cheep
         {
             Author = author,
-            Text = CheepText,
+            Text = sanitizedText,
             TimeStamp = DateTime.UtcNow
         };
 

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddScoped<ICheepRepository, CheepRepository>();
 builder.Services.AddScoped<IAuthorRepository, AuthorRepository>();
 builder.Services.AddScoped<ICheepService, CheepService>();
+builder.Services.AddScoped<IInputSanitizer, InputSanitizer>();
 
 builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddEntityFrameworkStores<ChirpContext>();


### PR DESCRIPTION
Created a class 'InputSanitizer' for cleaning user input.

I imported a package called HtmlSanitizer that - like the name says - sanitizes user input from xss attacks like '<script>alert('Hacked')</script>'. EF-Core and Razor Pages already provide a level of security with handling SQL injections by the use of LINQ queries and other...

I added 'builder.Services.AddScoped<IInputSanitizer, InputSanitizer>();' for context to the program.